### PR TITLE
Compatibility to leaflet ^1.0.3

### DIFF
--- a/leaflet.measure/leaflet.measure.js
+++ b/leaflet.measure/leaflet.measure.js
@@ -90,7 +90,7 @@ L.Control.Measure = L.Control.extend({
 			this._layerPaintPathTemp = L.polyline([this._lastPoint, e.latlng], { 
 				color: 'black',
 				weight: 1.5,
-				clickable: false,
+				interactive: false,
 				dashArray: '6,3'
 			}).addTo(this._layerPaint);
 		} else {
@@ -136,7 +136,7 @@ L.Control.Measure = L.Control.extend({
 			this._layerPaintPath = L.polyline([this._lastPoint], { 
 				color: 'black',
 				weight: 2,
-				clickable: false
+				interactive: false
 			}).addTo(this._layerPaint);
 		}
 
@@ -156,7 +156,8 @@ L.Control.Measure = L.Control.extend({
 			fill: true, 
 			fillOpacity: 1,
 			radius:2,
-			clickable: this._lastCircle ? true : false
+			interactive: this._lastCircle ? true : false,
+			bubblingMouseEvents: this._lastCircle ? false : true
 		}).addTo(this._layerPaint);
 		
 		this._lastCircle.on('click', function() { this._finishPath(); }, this);
@@ -197,7 +198,7 @@ L.Control.Measure = L.Control.extend({
 		});
 		this._tooltip = L.marker(position, { 
 			icon: icon,
-			clickable: false
+			interactive: false
 		}).addTo(this._layerPaint);
 	},
 

--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
   "bugs": {
     "url": "https://github.com/danwild/leaflet.measure/issues"
   },
-  "homepage": "https://github.com/danwild/leaflet.measure#readme"
+  "homepage": "https://github.com/danwild/leaflet.measure#readme",
+  "peerDependencies": {
+    "leaflet": "^1.0.3"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leaflet-measure-meters",
-  "version": "1.0.4",
+  "version": "2.0.1",
   "description": "Leaflet measure control =======================",
   "main": "leaflet.measure/leaflet.measure.js",
   "scripts": {


### PR DESCRIPTION
Changed all 
`clickable`
to
`interactive`

which was introduced in leaflet `1.0.3`

So this will work with leaflet >= `1.0.3`