### PR TITLE
Bug fix: Change default unitFactor so that the distance is in kilometres

### DIFF
--- a/leaflet.measure/leaflet.measure.js
+++ b/leaflet.measure/leaflet.measure.js
@@ -222,7 +222,7 @@ L.Control.Measure = L.Control.extend({
 	},
 
 	_round: function(val) {
-		const scale = this.options.measureOptions.unitFactor || 1;
+		const scale = this.options.measureOptions.unitFactor || 1000;
 		return Math.round((val / scale) * 10) / 10;
 	},
 


### PR DESCRIPTION
Hi, this PR is just to change the default unitFactor so that the distance is in kilometres, to match the default `km` label.